### PR TITLE
Add files via upload

### DIFF
--- a/SnapShot.txt
+++ b/SnapShot.txt
@@ -1,0 +1,132 @@
+voclabs:~/environment $ sudo su
+[root@ip-172-31-84-54 environment]# lsblk
+NAME      MAJ:MIN RM SIZE RO TYPE MOUNTPOINTS
+xvda      202:0    0  10G  0 disk
+├─xvda1   202:1    0  10G  0 part /
+├─xvda127 259:0    0   1M  0 part
+└─xvda128 259:1    0  10M  0 part /boot/efi
+[root@ip-172-31-84-54 environment]#
+Broadcast message from root@ip-172-31-22-136.us-west-2.compute.internal (Fri 2024-07-26 04:08:01 UTC):
+
+System shutdown has been cancelled
+
+
+[root@ip-172-31-84-54 environment]# lsblk
+NAME      MAJ:MIN RM SIZE RO TYPE MOUNTPOINTS
+xvda      202:0    0  10G  0 disk 
+├─xvda1   202:1    0  10G  0 part /
+├─xvda127 259:0    0   1M  0 part 
+└─xvda128 259:1    0  10M  0 part /boot/efi
+xvdb      202:16   0   9G  0 disk 
+[root@ip-172-31-84-54 environment]# mkdir -p /mnt/ebs_vol
+[root@ip-172-31-84-54 environment]# mkfs -t ext4 /dev/xvdb
+mke2fs 1.46.5 (30-Dec-2021)
+Creating filesystem with 2359296 4k blocks and 589824 inodes
+Filesystem UUID: 5133b55c-cf35-4a76-9679-d93c25432a4f
+Superblock backups stored on blocks: 
+        32768, 98304, 163840, 229376, 294912, 819200, 884736, 1605632
+
+Allocating group tables: done                            
+Writing inode tables: done                            
+Creating journal (16384 blocks): done
+Writing superblocks and filesystem accounting information: done 
+
+[root@ip-172-31-84-54 environment]# file -s /dev/xvdb
+/dev/xvdb: Linux rev 1.0 ext4 filesystem data, UUID=5133b55c-cf35-4a76-9679-d93c25432a4f (extents) (64bit) (large files) (huge files)
+[root@ip-172-31-84-54 environment]# mount /dev/xvdb /mnt/ebs_vol
+[root@ip-172-31-84-54 environment]# cd /mnt/ebs_vol/
+[root@ip-172-31-84-54 ebs_vol]# ls
+lost+found
+[root@ip-172-31-84-54 ebs_vol]# lslsll
+bash: lslsll: command not found
+[root@ip-172-31-84-54 ebs_vol]# lsblk
+NAME      MAJ:MIN RM SIZE RO TYPE MOUNTPOINTS
+xvda      202:0    0  10G  0 disk 
+├─xvda1   202:1    0  10G  0 part /
+├─xvda127 259:0    0   1M  0 part 
+└─xvda128 259:1    0  10M  0 part /boot/efi
+xvdb      202:16   0   9G  0 disk /mnt/ebs_vol
+[root@ip-172-31-84-54 ebs_vol]# cat >Sai
+ZPP High school
+Diplamo
+Btech
+thub
+^C
+[root@ip-172-31-84-54 ebs_vol]# cat sai
+cat: sai: No such file or directory
+[root@ip-172-31-84-54 ebs_vol]# cat Sai
+ZPP High school
+Diplamo
+Btech
+thub
+[root@ip-172-31-84-54 ebs_vol]# rm sai
+rm: cannot remove 'sai': No such file or directory
+[root@ip-172-31-84-54 ebs_vol]#  rm Sai
+rm: remove regular file 'Sai'? yes
+[root@ip-172-31-84-54 ebs_vol]# ls
+lost+found
+[root@ip-172-31-84-54 ebs_vol]# lsblk
+NAME      MAJ:MIN RM SIZE RO TYPE MOUNTPOINTS
+xvda      202:0    0  10G  0 disk 
+├─xvda1   202:1    0  10G  0 part /
+├─xvda127 259:0    0   1M  0 part 
+└─xvda128 259:1    0  10M  0 part /boot/efi
+xvdb      202:16   0   9G  0 disk /mnt/ebs_vol
+xvdc      202:32   0  10G  0 disk 
+[root@ip-172-31-84-54 ebs_vol]# mkdir -p /mnt/new_vol
+[root@ip-172-31-84-54 ebs_vol]# lsblk
+NAME      MAJ:MIN RM SIZE RO TYPE MOUNTPOINTS
+xvda      202:0    0  10G  0 disk 
+├─xvda1   202:1    0  10G  0 part /
+├─xvda127 259:0    0   1M  0 part 
+└─xvda128 259:1    0  10M  0 part /boot/efi
+xvdb      202:16   0   9G  0 disk /mnt/ebs_vol
+xvdc      202:32   0  10G  0 disk 
+[root@ip-172-31-84-54 ebs_vol]# mount /dev/xvdc /mnt/new_vol
+[root@ip-172-31-84-54 ebs_vol]# lsblk
+NAME      MAJ:MIN RM SIZE RO TYPE MOUNTPOINTS
+xvda      202:0    0  10G  0 disk 
+├─xvda1   202:1    0  10G  0 part /
+├─xvda127 259:0    0   1M  0 part 
+└─xvda128 259:1    0  10M  0 part /boot/efi
+xvdb      202:16   0   9G  0 disk /mnt/ebs_vol
+xvdc      202:32   0  10G  0 disk /mnt/new_vol
+[root@ip-172-31-84-54 ebs_vol]# df
+Filesystem     1K-blocks    Used Available Use% Mounted on
+devtmpfs            4096       0      4096   0% /dev
+tmpfs             486160       0    486160   0% /dev/shm
+tmpfs             194464    2912    191552   2% /run
+/dev/xvda1      10407916 7369872   3038044  71% /
+tmpfs             486160       0    486160   0% /tmp
+/dev/xvda128       10202    1310      8892  13% /boot/efi
+tmpfs              97232       0     97232   0% /run/user/1000
+/dev/xvdb        9186644      24   8698380   1% /mnt/ebs_vol
+/dev/xvdc        9186644      28   8698376   1% /mnt/new_vol
+[root@ip-172-31-84-54 ebs_vol]# cd ..
+[root@ip-172-31-84-54 mnt]# ls
+ebs_vol  new_vol
+[root@ip-172-31-84-54 mnt]# cd new_vol
+[root@ip-172-31-84-54 new_vol]# ls
+Sai  lost+found
+[root@ip-172-31-84-54 new_vol]# cat Sai
+ZPP High school
+Diplamo
+Btech
+thub
+[root@ip-172-31-84-54 new_vol]# cp /mnt/new_vol/sai /mnt/ebs_vol/
+cp: cannot stat '/mnt/new_vol/sai': No such file or directory
+[root@ip-172-31-84-54 new_vol]# cp /mnt/new_vol/Sai /mnt/ebs_vol/                                                                                                                                                                                   
+[root@ip-172-31-84-54 new_vol]# ls
+Sai  lost+found
+[root@ip-172-31-84-54 new_vol]# cd ..
+[root@ip-172-31-84-54 mnt]# ls
+ebs_vol  new_vol
+[root@ip-172-31-84-54 mnt]# cd ebs_vol
+[root@ip-172-31-84-54 ebs_vol]# ls
+Sai  lost+found
+[root@ip-172-31-84-54 ebs_vol]# cat Sai
+ZPP High school
+Diplamo
+Btech
+thub
+[root@ip-172-31-84-54 ebs_vol]# 


### PR DESCRIPTION
pointing in time copy the EBS volume

EBS volumes are block-level of storage that you can attach to EC2 instance to provide additional storage

An EC2 snapshot captures the data on an EBS volume, including the operating system, applications, and any data stored on the volume, at a specific moment

snapshots allows you to create backup of your EBS volume.in the event of data loss or correption you can use these snapshots to restore  your volumes to a previous state


snapshots can be used to migrate EBS volumes across different regions or availability zones



these also optimizing storage space and redusing costs